### PR TITLE
Factorial not using built-in function.

### DIFF
--- a/printNumbers/functions/factorial.py
+++ b/printNumbers/functions/factorial.py
@@ -26,4 +26,8 @@ def Factorial(n):
     :param n:  Operand
     :return:   n!
     '''
-    return(math.factorial(n))
+#    return(math.factorial(n))
+    fact=1
+    for i in range(1,n+1):
+      fact = fact * i
+    return fact


### PR DESCRIPTION
This modification does not use the built-in function factorial of Python. 